### PR TITLE
feat: 지원서 작성/수정 페이지 api 연결 추가 및 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.4.3",
         "react-router-dom": "^6.11.0",
         "recoil": "^0.7.7",
         "recoil-persist": "^4.2.0",
@@ -3597,6 +3598,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6809,6 +6818,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-intersection-observer": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.3",
     "react-router-dom": "^6.11.0",
     "recoil": "^0.7.7",
     "recoil-persist": "^4.2.0",

--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -25,7 +25,7 @@ axiosInstance.interceptors.response.use(
     //Refresh Token으로 새로운 AccessToken 요청
     try {
       const apiresult: Promise<any> = accessTokenAPI();
-      apiresult.then((res) => {
+      return apiresult.then((res) => {
         const newAccessToken = res.accessToken;
 
         //새로운 AccessToken으로 원래 요청 재시도
@@ -43,7 +43,6 @@ axiosInstance.interceptors.response.use(
       //refresh Token이 만료된 경우 메인 페이지로 이동
       window.location.replace('/');
     }
-    return Promise.reject(error);
   }
 );
 

--- a/src/api/applicationAPIS.ts
+++ b/src/api/applicationAPIS.ts
@@ -33,7 +33,7 @@ export const postApplicationAPI = async (form: ApplicationData) => {
 };
 
 //지원서 작성 완료 상태 수정
-export const patchApplicationState = async (formId: number) => {
+export const patchApplicationStateAPI = async (formId: number) => {
   try {
     await HttpClient.patch(`/api/application-forms/${formId}/state`, {}, {});
     return;
@@ -43,7 +43,7 @@ export const patchApplicationState = async (formId: number) => {
 };
 
 //지원서 문항 추가
-export const postApplicationQuestion = async (
+export const postApplicationQuestionAPI = async (
   formId: number,
   item: ApplicationEditItem
 ) => {
@@ -73,5 +73,33 @@ export const patchApplicationAPI = async (
     return response;
   } catch {
     return null;
+  }
+};
+
+//지원서 모두 조회 (커서 페이징, 동적 쿼리)
+//ex. /api/application-forms?cursor=2&size=2&year=2023
+// 쿼리 스트링은 nullable
+// cursor는 지원서의 id
+// cursor 없을 경우 디폴트 첫 데이터
+// size 없을 경우 디폴트 9개
+// year 없을 경우 년도 상관 없이 모두
+// 정렬은 마지막 수정 시간
+export const getAllApplicationAPI = async (
+  cursor: number | null,
+  size: number | null,
+  year: number | null
+) => {
+  const cursorParam = cursor ? `cursor=${cursor}` : '';
+  const sizeParam = size ? `size=${size}` : '';
+  const yearParam = year ? `year=${year}` : '';
+  const paramArr: string[] = [cursorParam, sizeParam, yearParam];
+  const param = paramArr.join('&');
+
+  const apiUrl = '/api/application-forms?' + param;
+  try {
+    const response = await HttpClient.get(apiUrl, {}, {});
+    return response;
+  } catch {
+    return [];
   }
 };

--- a/src/api/applicationAPIS.ts
+++ b/src/api/applicationAPIS.ts
@@ -33,9 +33,18 @@ export const postApplicationAPI = async (form: ApplicationData) => {
 };
 
 //지원서 작성 완료 상태 수정
-export const patchApplicationStateAPI = async (formId: number) => {
+export const patchApplicationStateAPI = async (
+  formId: number,
+  state: boolean
+) => {
   try {
-    await HttpClient.patch(`/api/application-forms/${formId}/state`, {}, {});
+    await HttpClient.patch(
+      `/api/application-forms/${formId}/state`,
+      {
+        isCompleted: state,
+      },
+      {}
+    );
     return;
   } catch {
     return;

--- a/src/api/folderAPIS.ts
+++ b/src/api/folderAPIS.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "@api/HttpClient";
+import { HttpClient } from '@api/HttpClient';
 
 // import {
 // } from '@pages/Main/componenets/YearMenu';
@@ -22,18 +22,14 @@ Authorization: Bearer ...
 
 export const getFolderAPI = async () => {
   try {
-    const response = await HttpClient.get(
-      '/api/application-folders',
-      {},
-      {}
-    );
+    const response = await HttpClient.get('/api/application-folders', {}, {});
     return response;
   } catch {
-    return null;
+    return [];
   }
-}
+};
 
-export const postFolderAPI = async (year: number) => {  
+export const postFolderAPI = async (year: number) => {
   try {
     const response = await HttpClient.post('/api/application-folders', year, {
       Accept: 'application/json',

--- a/src/components/Layout/PageContainer.tsx
+++ b/src/components/Layout/PageContainer.tsx
@@ -21,10 +21,10 @@ export const PageContainer = ({ children, header }: ListProps) => {
 };
 
 const PageContainerBox = styled.div`
-  margin-top: 75px;
   min-width: 1200px;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   background-color: black;
+  position: relative;
 `;

--- a/src/pages/ApplicationEdit/index.tsx
+++ b/src/pages/ApplicationEdit/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import { PageContainer } from '@components/Layout/PageContainer';
 import { ApplicationSearch } from '@pages/ApplicationWrite/search';
+import { getAllApplicationAPI } from '@api/applicationAPIS';
 import { ApplicationEditForm } from './edit';
 
 export const ApplicationEditPage = () => {
@@ -14,10 +15,18 @@ export const ApplicationEditPage = () => {
 
   useEffect(() => {
     setHasApplication(true);
+    const apireturn = getAllApplicationAPI(null, null, null);
+    apireturn
+      .then((res) => {
+        if (res.length > 0) setHasApplication(true);
+      })
+      .catch(() => {
+        setHasApplication(false);
+      });
   }, []);
 
   return (
-    <PageContainer>
+    <PageContainer header>
       <ApplicationPageContainer className={hasApplication ? '' : 'center'}>
         {hasApplication ? <ApplicationSearch /> : null}
         <ApplicationEditForm formId={Number(formId)} />
@@ -30,6 +39,7 @@ const ApplicationPageContainer = styled.div`
   width: 100vw;
   height: 100vh;
   min-width: 600px;
+  padding-top: 75px;
   display: flex;
   &.center {
     justify-content: center;

--- a/src/pages/ApplicationWrite/index.tsx
+++ b/src/pages/ApplicationWrite/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 
+import { getAllApplicationAPI } from '@api/applicationAPIS';
 import { PageContainer } from '@components/Layout/PageContainer';
 import { ApplicationSearch } from './search';
 import { ApplicationWrite } from './write';
@@ -11,6 +12,14 @@ export const ApplicationWritePage = () => {
 
   useEffect(() => {
     setHasApplication(true);
+    const apireturn = getAllApplicationAPI(null, null, null);
+    apireturn
+      .then((res) => {
+        if (res.length > 0) setHasApplication(true);
+      })
+      .catch(() => {
+        setHasApplication(false);
+      });
   }, []);
 
   return (

--- a/src/pages/ApplicationWrite/index.tsx
+++ b/src/pages/ApplicationWrite/index.tsx
@@ -37,6 +37,7 @@ const ApplicationPageContainer = styled.div`
   width: 100%;
   height: 100vh;
   min-width: 600px;
+  padding-top: 75px;
   display: flex;
   &.center {
     justify-content: center;

--- a/src/pages/ApplicationWrite/index.tsx
+++ b/src/pages/ApplicationWrite/index.tsx
@@ -11,7 +11,6 @@ export const ApplicationWritePage = () => {
   const [hasApplication, setHasApplication] = useState(false);
 
   useEffect(() => {
-    setHasApplication(true);
     const apireturn = getAllApplicationAPI(null, null, null);
     apireturn
       .then((res) => {

--- a/src/pages/ApplicationWrite/search/components/ApplicationDetail.tsx
+++ b/src/pages/ApplicationWrite/search/components/ApplicationDetail.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { State, SearchState } from '..';
 import { ApplicationItem } from './ApplicationItem';
 
-//import { getApplicationDetailAPI } from '@pages/Application/api/applicationAPIS';
+import { getApplicationDetailAPI } from '@api/applicationAPIS';
 
 import icon_back from '@assets/icons/icon-back.svg';
 
@@ -53,12 +53,14 @@ export const ApplicationDetail = ({ detailId, setSearchState }: propsType) => {
 
   //지원서 단건 조회해서 정보 가져옴
   useEffect(() => {
-    //TODO: 추후 api 호출 확인 후 주석 해제
-    // const apiReturn: Promise<any> = getApplicationDetailAPI(detailId);
-    // apiReturn.then((data: ApplicationData) => {
-    //   setApplicationDetail(data);
-    // });
-    setApplicationDetail(responseData);
+    const apiReturn: Promise<any> = getApplicationDetailAPI(detailId);
+    apiReturn
+      .then((data: ApplicationData) => {
+        setApplicationDetail(data);
+      })
+      .catch(() => {
+        setApplicationDetail(null);
+      });
   }, []);
 
   return (

--- a/src/pages/ApplicationWrite/search/components/ApplicationFolders.tsx
+++ b/src/pages/ApplicationWrite/search/components/ApplicationFolders.tsx
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { getAllApplicationAPI } from '@api/applicationAPIS';
+import { ApplicationFolder } from './ApplicationFolder';
+import { SearchState, ApplicationForm } from '..';
+
+interface propsType {
+  setSearchState: React.Dispatch<React.SetStateAction<SearchState>>;
+  setDetailId: React.Dispatch<React.SetStateAction<number>>;
+}
+const APIQUERYSIZE = 12;
+
+export const ApplicationFolders = ({
+  setSearchState,
+  setDetailId,
+}: propsType) => {
+  //지원서 목록
+  const [applications, setApplications] = useState<ApplicationForm[]>([]);
+  const [hasNextPage, setHasNextPage] = useState<boolean>(true);
+  const cursor = useRef<number | null>(null);
+  const [ref, inView] = useInView();
+
+  const fetch = useCallback(async () => {
+    const apireturn = getAllApplicationAPI(cursor.current, 12, null);
+    apireturn
+      .then((res: ApplicationForm[]) => {
+        //console.log(res);
+        setApplications((prevApplications) => [...prevApplications, ...res]);
+        setHasNextPage(res.length === APIQUERYSIZE);
+        if (res.length) {
+          if (cursor.current === null) cursor.current = 0;
+          cursor.current = res[res.length - 1].applicationFormId;
+          //console.log('cursor: ', cursor.current);
+        }
+      })
+      .catch(() => {
+        setHasNextPage(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    //console.log('inView:', inView, 'hasNextPage:', hasNextPage);
+    if (inView && hasNextPage) {
+      fetch();
+    }
+  }, [fetch, hasNextPage, inView]);
+
+  return (
+    <ApplicationFoldersContainer>
+      {applications.map((el) => {
+        return (
+          <ApplicationFolder
+            key={el.applicationFormId}
+            applicationFormId={el.applicationFormId}
+            recruiter={el.recruiter}
+            year={el.year}
+            semester={el.semester}
+            isCompleted={el.isCompleted}
+            setSearchState={setSearchState}
+            setDetailId={setDetailId}
+          />
+        );
+      })}
+      <RefContainer ref={ref}></RefContainer>
+    </ApplicationFoldersContainer>
+  );
+};
+
+const ApplicationFoldersContainer = styled.div`
+  height: 80%;
+  overflow-y: scroll;
+  /* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  position: relative;
+`;
+
+const RefContainer = styled.div`
+  width: 100px;
+  height: 1px;
+`;

--- a/src/pages/ApplicationWrite/search/index.tsx
+++ b/src/pages/ApplicationWrite/search/index.tsx
@@ -16,12 +16,25 @@ export interface SearchState {
   currentState: State;
 }
 
+interface ApplicationForm {
+  applicationFormId: number;
+  recruiter: string;
+  year: number;
+  semester: string;
+  isCompleted: boolean;
+  lastModifiedTime: string;
+}
+
+const APIQUERYSIZE = 9;
+
 export const ApplicationSearch = () => {
   const [searchState, setSearchState] = useState<SearchState>({
     currentState: State.all,
   });
   //지원서 상세보기에서 보여줄 지원서의 id
   const [detailId, setDetailId] = useState(0);
+  //지원서 목록
+  const [applications, setApplications] = useState<ApplicationForm[]>([]);
 
   return (
     <ApplicationSearchContainer>
@@ -93,9 +106,6 @@ const ApplicationSearchContainer = styled.div`
 `;
 
 const ApplicationFolders = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
   overflow-y: scroll;
   /* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
   &::-webkit-scrollbar {

--- a/src/pages/ApplicationWrite/search/index.tsx
+++ b/src/pages/ApplicationWrite/search/index.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { useState } from 'react';
 
 import { ApplicationSearchHeader } from './components/ApplicationSearchHeader';
-import { ApplicationFolder } from './components/ApplicationFolder';
+import { ApplicationFolders } from './components/ApplicationFolders';
 import { ApplicationDetail } from './components/ApplicationDetail';
 
 export enum State {
@@ -16,7 +16,7 @@ export interface SearchState {
   currentState: State;
 }
 
-interface ApplicationForm {
+export interface ApplicationForm {
   applicationFormId: number;
   recruiter: string;
   year: number;
@@ -25,16 +25,12 @@ interface ApplicationForm {
   lastModifiedTime: string;
 }
 
-const APIQUERYSIZE = 9;
-
 export const ApplicationSearch = () => {
   const [searchState, setSearchState] = useState<SearchState>({
     currentState: State.all,
   });
   //지원서 상세보기에서 보여줄 지원서의 id
   const [detailId, setDetailId] = useState(0);
-  //지원서 목록
-  const [applications, setApplications] = useState<ApplicationForm[]>([]);
 
   return (
     <ApplicationSearchContainer>
@@ -47,22 +43,10 @@ export const ApplicationSearch = () => {
       )}
       {/*전체 지원서 보기*/}
       {searchState.currentState === State.all ? (
-        <ApplicationFolders>
-          {responseData.map((el) => {
-            return (
-              <ApplicationFolder
-                key={el.applicationFormId}
-                applicationFormId={el.applicationFormId}
-                recruiter={el.recruiter}
-                year={el.year}
-                semester={el.semester}
-                isCompleted={el.isCompleted}
-                setSearchState={setSearchState}
-                setDetailId={setDetailId}
-              />
-            );
-          })}
-        </ApplicationFolders>
+        <ApplicationFolders
+          setSearchState={setSearchState}
+          setDetailId={setDetailId}
+        />
       ) : null}
       {/*지원서 상세 보기*/}
       {searchState.currentState === State.detail ? (
@@ -75,25 +59,6 @@ export const ApplicationSearch = () => {
   );
 };
 
-const responseData = [
-  {
-    applicationFormId: 1,
-    recruiter: '큐시즘',
-    year: 2023,
-    semester: 'first_half',
-    isCompleted: true,
-    lastModifiedDate: '2023-05-03T10:00:00',
-  },
-  {
-    applicationFormId: 2,
-    recruiter: 'sopt',
-    year: 2023,
-    semester: 'second_half',
-    isCompleted: false,
-    lastModifiedDate: '2023-05-01T10:00:00',
-  },
-];
-
 const ApplicationSearchContainer = styled.div`
   background-color: rgba(53, 56, 57, 0.5);
   min-width: 560px;
@@ -103,12 +68,4 @@ const ApplicationSearchContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-`;
-
-const ApplicationFolders = styled.div`
-  overflow-y: scroll;
-  /* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
-  &::-webkit-scrollbar {
-    display: none;
-  }
 `;

--- a/src/pages/ApplicationWrite/write/components/SaveModal.tsx
+++ b/src/pages/ApplicationWrite/write/components/SaveModal.tsx
@@ -40,26 +40,31 @@ export const SaveModal = ({ isOpen, setIsOpen, form }: propsType) => {
         const headers = response.headers;
         const location = headers['location'];
         const formId = Number(location.split('/').pop());
-        return formId;
+        return patchApplicationStateAPI(formId, true);
       })
-      .then((formId) => {
-        patchApplicationStateAPI(formId);
+      .then(() => {
         navigate('/');
       })
       .catch(() => {
-        setIsOpen(false);
+        navigate('/');
       });
   };
 
   const handleClickYesBtn = () => {
     //작성중으로 저장
-    const apiReturn: Promise<any> = postApplicationAPI(form);
-    apiReturn
+    axiosInstance
+      .post('/api/application-forms', form)
+      .then((response) => {
+        const headers = response.headers;
+        const location = headers['location'];
+        const formId = Number(location.split('/').pop());
+        return patchApplicationStateAPI(formId, false);
+      })
       .then(() => {
         navigate('/');
       })
       .catch(() => {
-        setIsOpen(false);
+        navigate('/');
       });
   };
 

--- a/src/pages/ApplicationWrite/write/components/SaveModal.tsx
+++ b/src/pages/ApplicationWrite/write/components/SaveModal.tsx
@@ -14,7 +14,7 @@ import {
 import { axiosInstance } from '@api/HttpClient';
 import {
   postApplicationAPI,
-  patchApplicationState,
+  patchApplicationStateAPI,
 } from '@api/applicationAPIS';
 import { ApplicationData } from '..';
 
@@ -43,7 +43,7 @@ export const SaveModal = ({ isOpen, setIsOpen, form }: propsType) => {
         return formId;
       })
       .then((formId) => {
-        patchApplicationState(formId);
+        patchApplicationStateAPI(formId);
         navigate('/');
       })
       .catch(() => {


### PR DESCRIPTION
## 📌 작업 내용
- 지원서 전체 조회 api로 사이드바에서 무한 스크롤 구현
- 지원서 작성 완료 api request 변경 반영
- axios interceptor에서 무한루프 방지하도록 수정
- 기타 지원서 작성/수정 페이지 기능 위주로 구현

## 📝 리뷰 요청
- api 연결해서 조건부 렌더링 하는 방법은 `src/ApplicationWrite/index.tsx` 참고하면 될거같은데 
   내일 회의전까지 시간있으면 보고와도 좋아~

## 💌 참고 사항
**무한 스크롤**
- intersection observer api 기반 라이브러리 사용
- 참고 블로그: https://devkkiri.com/post/927ae150-7627-4e25-b29f-2d0293b82332

## 📸 스크린샷

![스크린샷 2023-05-18 오전 12 01 09](https://github.com/kusitms-wannafly/wannafly_fe/assets/70098708/80dd16bb-61c7-4da1-a144-9bbd80bd196a)
