### PR TITLE
fix: 인증 관련 에러 처리 변경

### DIFF
--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-//import { accessTokenAPI } from './authAPIS';
+import { accessTokenAPI } from './authAPIS';
 
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -11,44 +11,44 @@ export const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-// axiosInstance.interceptors.response.use(
-//   (response) => {
-//     return response;
-//   },
-//   async (error) => {
-//     const originalRequest = error.config;
-//     if (error.response.status === 401 && !originalRequest._retry) {
-//       console.log('retry');
-//       //무한루프 방지
-//       originalRequest._retry = true;
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest._retry) {
+      console.log('retry');
+      //무한루프 방지
+      originalRequest._retry = true;
 
-//       //Refresh Token으로 새로운 AccessToken 요청
-//       try {
-//         const apiresult: Promise<any> = accessTokenAPI();
-//         return apiresult.then((res) => {
-//           const newAccessToken = res.accessToken;
+      //Refresh Token으로 새로운 AccessToken 요청
+      try {
+        const apiresult: Promise<any> = accessTokenAPI();
+        return apiresult.then((res) => {
+          const newAccessToken = res.accessToken;
 
-//           //새로운 AccessToken으로 원래 요청 재시도
-//           originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
-//           axiosInstance.defaults.headers.common[
-//             'Authorization'
-//           ] = `Bearer ${newAccessToken}`;
+          //새로운 AccessToken으로 원래 요청 재시도
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          axiosInstance.defaults.headers.common[
+            'Authorization'
+          ] = `Bearer ${newAccessToken}`;
 
-//           //로컬스토리지에 새로운 accessToken 저장
-//           localStorage.setItem('accessToken', `Bearer ${newAccessToken}`);
+          //로컬스토리지에 새로운 accessToken 저장
+          localStorage.setItem('accessToken', `Bearer ${newAccessToken}`);
 
-//           return axiosInstance(originalRequest);
-//         });
-//       } catch (err) {
-//         //refresh Token이 만료된 경우 메인 페이지로 이동
-//         window.location.replace('/');
-//         return Promise.reject(err);
-//       }
-//     } else {
-//       return Promise.reject(error);
-//     }
-//   }
-// );
+          return axiosInstance(originalRequest);
+        });
+      } catch (err) {
+        //refresh Token이 만료된 경우 메인 페이지로 이동
+        window.location.replace('/');
+        return Promise.reject(err);
+      }
+    } else {
+      return Promise.reject(error);
+    }
+  }
+);
 
 //http request 전 로컬스토리지에 있는 accessToken을 헤더에 포함
 axiosInstance.interceptors.request.use(

--- a/src/api/HttpClient.ts
+++ b/src/api/HttpClient.ts
@@ -18,7 +18,6 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
     if (error.response.status === 401 && !originalRequest._retry) {
-      console.log('retry');
       //무한루프 방지
       originalRequest._retry = true;
 

--- a/src/features/oauth/LoginAlert.tsx
+++ b/src/features/oauth/LoginAlert.tsx
@@ -12,7 +12,7 @@ export const LoginAlert = ({ loginState }: propsType) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (loginState === 'duplicateError') {
-        alert('중복된 이메일입니다.');
+        alert('이미 가입된 이메일입니다.');
       } else if (loginState === 'loginError') {
         alert('로그인에 실패했습니다.');
       }

--- a/src/features/oauth/LoginAlert.tsx
+++ b/src/features/oauth/LoginAlert.tsx
@@ -1,9 +1,7 @@
 import { useEffect } from 'react';
+import { LoginState } from './types';
 
-interface propsType {
-  loginState: string;
-}
-export const LoginAlert = ({ loginState }: propsType) => {
+export const LoginAlert = () => {
   //로그인 실패
   //duplicateError: 이메일 중복
   //loginError: 기타 소셜로그인 에러
@@ -11,10 +9,13 @@ export const LoginAlert = ({ loginState }: propsType) => {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (loginState === 'duplicateError') {
+      const loginState = localStorage.getItem('loginState');
+      if (loginState === LoginState[1]) {
         alert('이미 가입된 이메일입니다.');
-      } else if (loginState === 'loginError') {
+        localStorage.setItem('loginState', LoginState[0]);
+      } else if (loginState === LoginState[2]) {
         alert('로그인에 실패했습니다.');
+        localStorage.setItem('loginState', LoginState[0]);
       }
     }, 500);
     return () => {

--- a/src/features/oauth/LoginRedirect.tsx
+++ b/src/features/oauth/LoginRedirect.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { LoginState } from './types';
 
 export const LoginRedirect = () => {
   const navigate = useNavigate();
@@ -10,20 +11,18 @@ export const LoginRedirect = () => {
   );
   const errorCode = new URL(window.location.href).searchParams.get('errorCode');
 
-  let loginState = '';
-
   //로그인 에러 발생
   if (errorCode !== null) {
     if (errorCode === '1001') {
       //이메일 중복 에러
       localStorage.setItem('accessToken', '');
       localStorage.setItem('isLogin', 'false');
-      loginState = 'duplicateError';
+      localStorage.setItem('loginState', LoginState[1]);
     } else {
       //다른 로그인 에러
       localStorage.setItem('accessToken', '');
       localStorage.setItem('isLogin', 'false');
-      loginState = 'loginError';
+      localStorage.setItem('loginState', LoginState[2]);
     }
   } else {
     //로그인 성공
@@ -31,17 +30,11 @@ export const LoginRedirect = () => {
     //refreshToken - httpOnly 쿠키로 저장
     localStorage.setItem('accessToken', 'Bearer ' + accessToken);
     localStorage.setItem('isLogin', 'true');
-    loginState = 'success';
-    //axios instance default header 설정
-    // axiosInstance.defaults.headers.common[
-    //   'Authorization'
-    // ] = `Bearer ${accessToken}`;
-    //navigate('/', { replace: true });
+    localStorage.setItem('loginState', LoginState[3]);
   }
 
-  //TODO: 중복 email시 errorCode 처리
   useEffect(() => {
-    navigate('/', { replace: true, state: { loginState: loginState } });
+    navigate('/', { replace: true });
   }, []);
   return <></>;
 };

--- a/src/features/oauth/types.ts
+++ b/src/features/oauth/types.ts
@@ -1,0 +1,6 @@
+export enum LoginState {
+  'NotLogined',
+  'Duplicate',
+  'Error',
+  'Success',
+}

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -2,15 +2,10 @@ import { PageContainer } from '@components/Layout/PageContainer';
 import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { LoginAlert } from '@features/oauth/LoginAlert';
-import { useLocation } from 'react-router-dom';
-
 import { NotLoginPage } from './components/NotLoginPage';
 import { LoginPage } from './components/LoginPage';
 
 export const MainPage = () => {
-  const location = useLocation();
-  const loginState = location.state?.loginState;
-
   const [isLogin, setIsLogin] = useState<boolean>(false);
 
   useEffect(() => {
@@ -26,7 +21,7 @@ export const MainPage = () => {
     <PageContainer header>
       <MainPageContainer>
         {isLogin ? <LoginPage /> : <NotLoginPage />}
-        <LoginAlert loginState={loginState} />
+        <LoginAlert />
       </MainPageContainer>
     </PageContainer>
   );


### PR DESCRIPTION
## 📌 작업 내용
- axios interceptor로 response에서 401 에러 상황에서 accessToken 재발급 무한루프되는 버그 해결
- 로그인 실패시 에러코드에 따라 중복 이메일 / 기타 로그인 에러 alert창 추가
- 로그인 실패 상태 관리 위해 enum 사용, 로컬 스토리지에 `loginState` 저장
  (그냥 navigate에 state 담는 방식 / 컴포넌트에 useState로 저장했을 때는 계속해서 alert 창이 뜸)

## 📝 리뷰 요청

## 💌 참고 사항

## 📸 스크린샷
<img width="1156" alt="image" src="https://github.com/kusitms-wannafly/wannafly_fe/assets/70098708/d3c0e341-c8f2-414c-b1d5-d8b31ce1e60d">