### PR TITLE
feat: 작성하기 페이지에 유형별 카테고리 조회 추가

### DIFF
--- a/src/components/modals/CostModal.tsx
+++ b/src/components/modals/CostModal.tsx
@@ -39,6 +39,7 @@ const CostModalContainer = styled.div`
 `;
 
 const ModalBackdrop = styled.div`
+  z-index: 1000;
   background: rgba(0, 0, 0, 0.5);
   position: fixed;
   left: 0;

--- a/src/pages/ApplicationWrite/search/components/Categories.tsx
+++ b/src/pages/ApplicationWrite/search/components/Categories.tsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+
+import { CategoryHeader } from './CategoryHeader';
+import { CategoryItems } from './CategoryItems';
+import { getAllCategoriesAPI } from '@api/categoryAPIS';
+
+export interface Category {
+  categoryId: number;
+  name: string;
+}
+
+export const Categories = () => {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number>(0);
+
+  const getAllCategories = () => {
+    const apireturn = getAllCategoriesAPI();
+    apireturn
+      .then((res) => {
+        setCategories(res);
+        setSelectedCategoryId(res[0].categoryId);
+      })
+      .catch(() => {
+        setCategories([]);
+      });
+  };
+
+  useEffect(() => {
+    getAllCategories();
+  }, []);
+
+  return (
+    <CategoriesContainer>
+      <CategoryHeader
+        categories={categories}
+        selectedCategoryId={selectedCategoryId}
+        setSelectedCategoryId={setSelectedCategoryId}
+      />
+      <CategoryItems selectedCategoryId={selectedCategoryId} />
+    </CategoriesContainer>
+  );
+};
+
+const CategoriesContainer = styled.div`
+  width: 100%;
+  height: 85%;
+  padding: 0 20px;
+`;

--- a/src/pages/ApplicationWrite/search/components/CategoryHeader.tsx
+++ b/src/pages/ApplicationWrite/search/components/CategoryHeader.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+
+import { Category } from './Categories';
+
+interface propsType {
+  categories: Category[];
+  selectedCategoryId: number;
+  setSelectedCategoryId: React.Dispatch<React.SetStateAction<number>>;
+}
+export const CategoryHeader = ({
+  categories,
+  selectedCategoryId,
+  setSelectedCategoryId,
+}: propsType) => {
+  const handleClickCategoryBtn = (categoryId: number) => {
+    setSelectedCategoryId(categoryId);
+  };
+
+  return (
+    <CategoryHeaderContainer>
+      {categories.map((el) => {
+        return (
+          <CategoryBtn
+            key={el.categoryId}
+            className={el.categoryId === selectedCategoryId ? 'selected' : ''}
+            onClick={() => {
+              handleClickCategoryBtn(el.categoryId);
+            }}
+          >
+            {el.name}
+          </CategoryBtn>
+        );
+      })}
+    </CategoryHeaderContainer>
+  );
+};
+
+const CategoryHeaderContainer = styled.div`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const CategoryBtn = styled.button`
+  height: 36px;
+  border: none;
+  margin: 0;
+  padding: 10px 15px;
+  border-radius: 18px;
+  margin-right: 8px;
+  margin-bottom: 8px;
+
+  background-color: ${({ theme }) => theme.colors.grey6};
+  color: ${({ theme }) => theme.colors.navy2};
+  font-family: 'PretendardMedium';
+
+  display: flex;
+  align-content: center;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &.selected {
+    background-color: ${({ theme }) => theme.colors.navy2};
+    color: ${({ theme }) => theme.colors.navy5};
+  }
+`;

--- a/src/pages/ApplicationWrite/search/components/CategoryItems.tsx
+++ b/src/pages/ApplicationWrite/search/components/CategoryItems.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import { CategorizedItem as CategorizedItemType } from '@pages/Categorize/Edit/Categorized';
+import { CategorizedItem } from '@pages/Categorize/Edit/CategorizedItem';
+import { CostModal } from '@components/modals/CostModal';
+import { getCategorizedItemsAPI } from '@api/categoryAPIS';
+
+interface propsType {
+  selectedCategoryId: number;
+}
+export const CategoryItems = ({ selectedCategoryId }: propsType) => {
+  const [items, setItems] = useState<CategorizedItemType[]>([]);
+  const [isOpenCostModal, setIsOpenCostModal] = useState<boolean>(false);
+
+  useEffect(() => {
+    const apireturn = getCategorizedItemsAPI(selectedCategoryId);
+    apireturn
+      .then((res) => {
+        setItems(res);
+      })
+      .catch(() => {
+        setItems([]);
+      });
+  }, [selectedCategoryId]);
+
+  return (
+    <CategoryItemsContainer>
+      {items.slice(0, 3)?.map((el, idx) => {
+        return <CategorizedItem key={idx} index={idx} item={el} />;
+      })}
+      {items.length > 3 ? (
+        <ShowMoreContainer>
+          <ShowMoreBtn
+            onClick={() => {
+              setIsOpenCostModal(!isOpenCostModal);
+            }}
+          >
+            더보기
+          </ShowMoreBtn>
+        </ShowMoreContainer>
+      ) : null}
+      <CostModal isOpen={isOpenCostModal} setIsOpen={setIsOpenCostModal} />
+    </CategoryItemsContainer>
+  );
+};
+
+const CategoryItemsContainer = styled.div`
+  width: 100%;
+  height: calc(100% - 60px);
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  padding-bottom: 40px;
+`;
+
+const ShowMoreContainer = styled.div`
+  width: 100%;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ShowMoreBtn = styled.button`
+  background-color: transparent;
+  border: none;
+  color: ${({ theme }) => theme.colors.wht};
+  font-family: 'PretendardBold';
+  &:hover {
+    cursor: pointer;
+    color: ${({ theme }) => theme.colors.navy2};
+  }
+`;

--- a/src/pages/ApplicationWrite/search/index.tsx
+++ b/src/pages/ApplicationWrite/search/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { ApplicationSearchHeader } from './components/ApplicationSearchHeader';
 import { ApplicationFolders } from './components/ApplicationFolders';
 import { ApplicationDetail } from './components/ApplicationDetail';
+import { Categories } from './components/Categories';
 
 export enum State {
   all = '전체 지원서',
@@ -55,6 +56,8 @@ export const ApplicationSearch = () => {
           setSearchState={setSearchState}
         />
       ) : null}
+      {/* 유형별 카테고리 */}
+      {searchState.currentState === State.category ? <Categories /> : null}
     </ApplicationSearchContainer>
   );
 };

--- a/src/pages/Categorize/Edit/CategorizedItem.tsx
+++ b/src/pages/Categorize/Edit/CategorizedItem.tsx
@@ -14,9 +14,9 @@ export const CategorizedItem = ({ index, item }: propsType) => {
       <QuestionContainer>
         <QuestionNumber>{`Q${index + 1}`}</QuestionNumber>
         <Question>{item.applicationItem.applicationQuestion}</Question>
-        <MinusBtn>
+        {/* <MinusBtn>
           <img src={icon_minus} alt="제거하기" />
-        </MinusBtn>
+        </MinusBtn> */}
       </QuestionContainer>
       <Answer>{item.applicationItem.applicationAnswer}</Answer>
       <InfoConatiner>


### PR DESCRIPTION
## 📌 작업 내용
- 지원서 작성/수정 페이지에서 유형별 카테고리 조회 가능
- 카테고리별 지원서는 3개까지만 조회 가능, 이후 더보기 버튼 클릭시 유료화 모달

## 📝 리뷰 요청


## 💌 참고 사항


## 📸 스크린샷
![image](https://github.com/kusitms-wannafly/wannafly_fe/assets/70098708/c07e16a4-b216-478d-ada4-4a6477843fde)
